### PR TITLE
fix: modified carts tests for multiple payment notices

### DIFF
--- a/api-tests/cart-tests/cart-api-dev.tests.json
+++ b/api-tests/cart-tests/cart-api-dev.tests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "deee9d12-69c3-4f8d-b8c1-7df7a7aa840c",
+		"_postman_id": "2106a0e2-49b9-431e-85c2-52be64ae987e",
 		"name": "Carts API (DEV)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "23963988"
@@ -97,6 +97,56 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"1\",\n            \"amount\": 10000,\n            \"companyName\": null,\n            \"description\": null\n        }\n    ],\n    \"returnurls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://api.dev.platform.pagopa.it/checkout/ec/v1/carts",
+					"protocol": "https",
+					"host": [
+						"api",
+						"dev",
+						"platform",
+						"pagopa",
+						"it"
+					],
+					"path": [
+						"checkout",
+						"ec",
+						"v1",
+						"carts"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Post carts KO Multiple payment notices",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 400 with more than 5 payment notices\", () => {",
+							"  pm.expect(pm.response.code).to.eql(400);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009421\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"AA\",\n            \"description\": \"BB\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009422\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"CC\",\n            \"description\": \"DD\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009423\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"EE\",\n            \"description\": \"FF\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"GG\",\n            \"description\": \"HH\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009425\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"JJ\",\n            \"description\": \"KK\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009426\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"II\",\n            \"description\": \"LL\"\n        }\n    ],\n    \"returnUrls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/api-tests/cart-tests/cart-api-dev.tests.json
+++ b/api-tests/cart-tests/cart-api-dev.tests.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "1eaf682b-38c1-4247-aab8-d2eb22512a0a",
+		"_postman_id": "deee9d12-69c3-4f8d-b8c1-7df7a7aa840c",
 		"name": "Carts API (DEV)",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "23963988"
 	},
 	"item": [
 		{
@@ -96,56 +97,6 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"1\",\n            \"amount\": 10000,\n            \"companyName\": null,\n            \"description\": null\n        }\n    ],\n    \"returnurls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "https://api.dev.platform.pagopa.it/checkout/ec/v1/carts",
-					"protocol": "https",
-					"host": [
-						"api",
-						"dev",
-						"platform",
-						"pagopa",
-						"it"
-					],
-					"path": [
-						"checkout",
-						"ec",
-						"v1",
-						"carts"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Post carts KO Multiple payment notices",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 422 with multiple payment notices\", () => {",
-							"  pm.expect(pm.response.code).to.eql(422);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disabledSystemHeaders": {}
-			},
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"AA\",\n            \"description\": \"BB\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009425\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"CC\",\n            \"description\": \"DD\"\n        }\n    ],\n    \"returnUrls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/api-tests/cart-tests/cart-api-uat.tests.json
+++ b/api-tests/cart-tests/cart-api-uat.tests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "486671c7-3fef-42ce-96ad-2ecee8d08372",
+		"_postman_id": "287b063a-28c2-4f82-b133-ca388250ae83",
 		"name": "Carts API (UAT)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "23963988"
@@ -110,6 +110,62 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"1\",\n            \"amount\": 10000,\n            \"companyName\": null,\n            \"description\": null\n        }\n    ],\n    \"returnurls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://api.uat.platform.pagopa.it/checkout/ec/v1/carts",
+					"protocol": "https",
+					"host": [
+						"api",
+						"uat",
+						"platform",
+						"pagopa",
+						"it"
+					],
+					"path": [
+						"checkout",
+						"ec",
+						"v1",
+						"carts"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Post carts KO Multiple payment notices",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 400 with more than 5 payment notices\", () => {",
+							"  pm.expect(pm.response.code).to.eql(400);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "deployment",
+						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009421\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"AA\",\n            \"description\": \"BB\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009422\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"CC\",\n            \"description\": \"DD\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009423\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"EE\",\n            \"description\": \"FF\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"GG\",\n            \"description\": \"HH\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009425\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"JJ\",\n            \"description\": \"KK\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009426\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"II\",\n            \"description\": \"LL\"\n        }\n    ],\n    \"returnUrls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/api-tests/cart-tests/cart-api-uat.tests.json
+++ b/api-tests/cart-tests/cart-api-uat.tests.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "2830f361-9c43-4257-9914-46756ae18d99",
+		"_postman_id": "486671c7-3fef-42ce-96ad-2ecee8d08372",
 		"name": "Carts API (UAT)",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "23963988"
 	},
 	"item": [
 		{
@@ -109,63 +110,6 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"1\",\n            \"amount\": 10000,\n            \"companyName\": null,\n            \"description\": null\n        }\n    ],\n    \"returnurls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "https://api.uat.platform.pagopa.it/checkout/ec/v1/carts",
-					"protocol": "https",
-					"host": [
-						"api",
-						"uat",
-						"platform",
-						"pagopa",
-						"it"
-					],
-					"path": [
-						"checkout",
-						"ec",
-						"v1",
-						"carts"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Post carts KO Multiple payment notices",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 422 with multiple payment notices\", () => {",
-							"  pm.expect(pm.response.code).to.eql(422);",
-							"",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disabledSystemHeaders": {}
-			},
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "deployment",
-						"value": "{{DEPLOYMENT}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"paymentNotices\": [\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"AA\",\n            \"description\": \"BB\"\n        },\n        {\n            \"noticeNumber\": \"302000100440009424\",\n            \"fiscalCode\": \"11111111111\",\n            \"amount\": 10000,\n            \"companyName\": \"CC\",\n            \"description\": \"DD\"\n        }\n    ],\n    \"returnUrls\": {\n        \"returnOkUrl\": \"https://returnOkUrl\",\n        \"returnCancelUrl\": \"https://returnCancelUrl\",\n        \"returnErrorUrl\": \"https://returnErrorUrl\"\n    },\n    \"emailNotice\": \"test@test.it\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Modified `Post carts KO Multiple payment notices` from Carts test collections since 1 payment notice per cart limitation has been removed as for PR https://github.com/pagopa/pagopa-ecommerce-payment-requests-service/pull/52
Test will be performed with 6 payment notices and check is performed against 400 bad request expected return code
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This modification is needed in order to align carts API tests to the actual payment request implementation
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local test with Postman
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
