### PR TITLE
[CHK-1691] feat: add payment request verification cache hit

### DIFF
--- a/api-tests/checkout-tests/checkout-for-ecommerce-api.tests.json
+++ b/api-tests/checkout-tests/checkout-for-ecommerce-api.tests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "96efc315-3f91-491a-866f-1cc15713457b",
+		"_postman_id": "7eb0ae9e-9744-4aed-b3ce-9a03e9f13bb2",
 		"name": "Ecommerce for Checkout API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "23963988"
@@ -971,13 +971,13 @@
 					}
 				],
 				"url": {
-					"raw": "{{CHECKOUT_HOST}}/ecommerce/payment-methods-service/v1/payment-methods",
+					"raw": "{{CHECKOUT_HOST}}/ecommerce/checkout/v1/payment-methods",
 					"host": [
 						"{{CHECKOUT_HOST}}"
 					],
 					"path": [
 						"ecommerce",
-						"payment-methods-service",
+						"checkout",
 						"v1",
 						"payment-methods"
 					]

--- a/api-tests/checkout-tests/checkout-for-ecommerce-api.tests.json
+++ b/api-tests/checkout-tests/checkout-for-ecommerce-api.tests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "d1dc9605-4e01-429a-b98c-9d518024605e",
+		"_postman_id": "96efc315-3f91-491a-866f-1cc15713457b",
 		"name": "Ecommerce for Checkout API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "23305473"
+		"_exporter_id": "23963988"
 	},
 	"item": [
 		{
@@ -413,6 +413,90 @@
 						"checkout",
 						"v1",
 						"transactions"
+					],
+					"query": [
+						{
+							"key": "recaptchaResponse",
+							"value": "token"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Payment Verify - Success Cache hit",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Payment Verify cache hit - Status code is 200 with valid json response\", function(){",
+							"    ",
+							"    const responseJson = pm.response.json();",
+							"",
+							"    pm.response.to.have.status(200);",
+							"",
+							"    const requestRptId = pm.environment.get(\"VALID_FISCAL_CODE_PA\") + pm.environment.get(\"VALID_NOTICE_CODE\");",
+							"    const fixedDueDate = pm.environment.get(\"DUE_DATE\")",
+							"    const dueDate = fixedDueDate ==null ? new Date().toISOString().split('T')[0] : fixedDueDate;",
+							"    const amount = parseInt(pm.environment.get(\"AMOUNT\"));",
+							"    const expected = {",
+							"        \"amount\": amount,",
+							"        \"rptId\": requestRptId,",
+							"        \"paFiscalCode\": \"77777777777\",",
+							"        \"dueDate\": dueDate",
+							"    };",
+							"",
+							"    pm.expect(responseJson.amount).eql(expected.amount);",
+							"    pm.expect(responseJson.rptId).eql(expected.rptId);",
+							"    pm.expect(responseJson.paFiscalCode).eql(expected.paFiscalCode);",
+							"    pm.expect(responseJson.dueDate).eql(expected.dueDate);",
+							"    pm.expect(responseJson.description).to.be.a.string;",
+							"    pm.expect(responseJson.paName).to.be.a.string;",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true,
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "deployment",
+						"value": "{{DEPLOYMENT_PAYMENT_REQUESTS}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": []
+				},
+				"url": {
+					"raw": "{{CHECKOUT_HOST}}/ecommerce/checkout/v1/payment-requests/{{VALID_FISCAL_CODE_PA}}{{VALID_NOTICE_CODE}}?recaptchaResponse=token",
+					"host": [
+						"{{CHECKOUT_HOST}}"
+					],
+					"path": [
+						"ecommerce",
+						"checkout",
+						"v1",
+						"payment-requests",
+						"{{VALID_FISCAL_CODE_PA}}{{VALID_NOTICE_CODE}}"
 					],
 					"query": [
 						{


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- Add verifications cache hit test. This test consist into make same verifications request after transaction activation.
- Fix payment method get all payment methods url to ecommerce/checkout api group

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This test allow to test the cache hit mechanism.
Making verification request after transaction activation this a test is performed against redis cache deserialization payment-requests side after it has been updated by transactions-service allowing detection of cache fields mismatch

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Collection run locally for UAT env
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
