### PR TITLE
test(e2e): add test to check error message fpr unavailable psp

### DIFF
--- a/e2e-tests/src/npg/helpers.js
+++ b/e2e-tests/src/npg/helpers.js
@@ -82,16 +82,11 @@ export const fillEmailForm = async email => {
   await continueBtn.click();
 };
 
-export const choosePaymentMethod = async method => {
-  const cardOptionXPath = '/html/body/div[1]/div/div[2]/div/div[2]/div/div[1]/div[1]/div';
+export const choosePaymentMethod = async (method) => {
+  const cardOptionXPath = `[data-qaid=${method}]`;
 
-  switch (method) {
-    case 'card': {
-      const cardOptionBtn = await page.waitForXPath(cardOptionXPath);
-      await cardOptionBtn.click();
-      break;
-    }
-  }
+  const cardOptionBtn = await page.waitForSelector(cardOptionXPath);
+  await cardOptionBtn.click();
 };
 
 const execute_mock_authorization_npg = async () => {

--- a/e2e-tests/src/npg/psp-unavailable-error.npg.integration.test.ts
+++ b/e2e-tests/src/npg/psp-unavailable-error.npg.integration.test.ts
@@ -1,0 +1,75 @@
+import { choosePaymentMethod, fillEmailForm, fillPaymentNotificationForm } from "./helpers";
+
+/**
+ * Test input and configuration
+ */
+const CHECKOUT_URL = String(process.env.CHECKOUT_URL);
+const VALID_FISCAL_CODE = String(process.env.VALID_FISCAL_CODE);
+const EMAIL = String(process.env.EMAIL);
+
+/**
+ * Increase default test timeout (120000ms)
+ * to support entire payment flow
+  */
+
+const timeout = 80_000
+jest.setTimeout(timeout);
+jest.retryTimes(2);
+page.setDefaultNavigationTimeout(timeout);
+page.setDefaultTimeout(timeout)
+
+beforeAll( async () => {
+  await page.goto(CHECKOUT_URL);
+  await page.setViewport({ width: 1200, height: 907 });
+})
+
+beforeEach(async () => {
+  await page.goto(CHECKOUT_URL);
+});
+
+
+describe("Checkout fails to calculate fee", () => {
+
+  it("Should fails calculate fee with 404", async() => {
+   
+    // notice code with 6000 euro as amount (according Mock EC)
+    const PSP_NOT_FOUND_FAIL = "30212" + Math.floor(Math.pow(10, 12) + Math.random() * 9 * Math.pow(10, 12))
+    const pspNotFoundTitleTextExpected = "Il metodo di pagamento selezionato non è disponibile";
+    const pspNotFoundCtaTextExpected = "Scegli un altro metodo";
+    const errorDescriptionTextExpected = "Può succedere quando l’importo da pagare è particolarmente elevato, o se stai cercando di pagare una marca da bollo digitale.";
+
+    console.log(
+      `Testing error message psp unavailable given SATISPAY given amaount of 6000 euro .
+      notice code: ${PSP_NOT_FOUND_FAIL},
+      fiscal code: ${VALID_FISCAL_CODE}
+      `,
+    );
+
+    const payNoticeBtnSelector = '#paymentSummaryButtonPay';
+    await fillPaymentNotificationForm(PSP_NOT_FOUND_FAIL, VALID_FISCAL_CODE);
+  
+    const payNoticeBtn = await page.waitForSelector(payNoticeBtnSelector);
+    await payNoticeBtn.click();
+    await fillEmailForm(EMAIL);
+    await choosePaymentMethod('BPAY');
+    
+    const pspNotFoundTitleId = "#pspNotFoundTitleId";
+    const pspNotFoundTitleElem = await page.waitForSelector(
+      pspNotFoundTitleId
+    );
+    const pspNotFoundTitleText = await pspNotFoundTitleElem.evaluate((el) => el.textContent);
+    expect(pspNotFoundTitleText).toContain(pspNotFoundTitleTextExpected);
+
+    const pspNotFoundCtaId = "#pspNotFoundCtaId";
+    const pspNotFoundCtaElem = await page.waitForSelector(pspNotFoundCtaId);
+    const pspNotFoundCtaText = await pspNotFoundCtaElem.evaluate((el) => el.textContent);
+    expect(pspNotFoundCtaText).toContain(pspNotFoundCtaTextExpected);
+
+    const errorDescriptionId = "#pspNotFoundBodyId";
+    const errorDescriptionElem = await page.waitForSelector(errorDescriptionId);
+    const errorDescriptionText = await errorDescriptionElem.evaluate((el) => el.textContent);
+    expect(errorDescriptionText).toContain(errorDescriptionTextExpected);
+
+  });
+
+});

--- a/e2e-tests/src/npg/psp-unavailable-error.npg.integration.test.ts
+++ b/e2e-tests/src/npg/psp-unavailable-error.npg.integration.test.ts
@@ -70,6 +70,11 @@ describe("Checkout fails to calculate fee", () => {
     const errorDescriptionText = await errorDescriptionElem.evaluate((el) => el.textContent);
     expect(errorDescriptionText).toContain(errorDescriptionTextExpected);
 
+    
+    await pspNotFoundCtaElem.click();
+ 
+    const currentUrl = await page.evaluate(() => location.href);
+    expect(currentUrl).toContain("/scegli-metodo");
   });
 
 });

--- a/e2e-tests/src/npg/psp-unavailable-error.npg.integration.test.ts
+++ b/e2e-tests/src/npg/psp-unavailable-error.npg.integration.test.ts
@@ -39,7 +39,7 @@ describe("Checkout fails to calculate fee", () => {
     const errorDescriptionTextExpected = "Può succedere quando l’importo da pagare è particolarmente elevato, o se stai cercando di pagare una marca da bollo digitale.";
 
     console.log(
-      `Testing error message psp unavailable given SATISPAY given amaount of 6000 euro .
+      `Testing error message psp unavailable given BancomatPay given amaount of 6000 euro .
       notice code: ${PSP_NOT_FOUND_FAIL},
       fiscal code: ${VALID_FISCAL_CODE}
       `,

--- a/e2e-tests/src/npg/psp-unavailable-error.npg.integration.test.ts
+++ b/e2e-tests/src/npg/psp-unavailable-error.npg.integration.test.ts
@@ -30,7 +30,7 @@ beforeEach(async () => {
 
 describe("Checkout fails to calculate fee", () => {
 
-  it("Should fails calculate fee with 404", async() => {
+  it("Should fails calculate fee with 404 and show a dedicated error message", async() => {
    
     // notice code with 6000 euro as amount (according Mock EC)
     const PSP_NOT_FOUND_FAIL = "30212" + Math.floor(Math.pow(10, 12) + Math.random() * 9 * Math.pow(10, 12))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- update e2e test

#### Motivation and Context

The goal of this PR is to add e2e tests to check error messages in case of unavailable PSP like for "Marca da bollo" or for too high amounts. Tests were done for the BancomatPay to test the message in the method selection page.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run test locally on in deploy pipeline

#### Screenshots (if appropriate):

<img width="757" alt="Screenshot 2024-10-30 alle 08 02 31" src="https://github.com/user-attachments/assets/e3460d61-b603-4d8e-9d91-29fb436f6364">


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
