### PR TITLE
Feat [CHK-3353] Fixed int tests accordingly to new Checkout-FE html structure

### DIFF
--- a/e2e-tests/src/npg/helpers.js
+++ b/e2e-tests/src/npg/helpers.js
@@ -1,5 +1,5 @@
 export const selectKeyboardForm = async () => {
-  const selectFormXPath = '/html/body/div[1]/div/div[2]/div/div[2]/div[2]/div[1]/div/div/div[1]';
+  const selectFormXPath = '/html/body/div[1]/div/main/div/div[2]/div[2]/div[1]/div/div/div[1]';
 
   const selectFormBtn = await page.waitForXPath(selectFormXPath);
   await selectFormBtn.click();
@@ -52,7 +52,7 @@ export const payNotice = async (noticeCode, fiscalCode, email, cardData, abi) =>
     `,
   );
   const payNoticeBtnSelector = '#paymentSummaryButtonPay';
-  const resultMessageXPath = '/html/body/div[1]/div/div[2]/div/div/div/div/h6';
+  const resultMessageXPath = '/html/body/div[1]/div/main/div/div/div/div/h6';
   await fillPaymentNotificationForm(noticeCode, fiscalCode);
 
   const payNoticeBtn = await page.waitForSelector(payNoticeBtnSelector);
@@ -140,7 +140,7 @@ export const fillCardDataForm = async (cardData, abi) => {
   const continueBtnXPath = 'button[type=submit]';
   const disabledContinueBtnXPath = 'button[type=submit][disabled=""]';
   const payBtnSelector = '#paymentCheckPageButtonPay';
-  const selectPSPXPath = '/html/body/div[1]/div/div[2]/div/div/div[5]/button';
+  const selectPSPXPath = '/html/body/div[1]/div/main/div/div/div[5]/button';
   let iteration = 0;
   let completed = false;
   while (!completed) {

--- a/e2e-tests/src/npg/psp-sorting.npg.integration.test.ts
+++ b/e2e-tests/src/npg/psp-sorting.npg.integration.test.ts
@@ -30,7 +30,7 @@ beforeEach(async () => {
 });
 
 
-describe.only("Checkout show and sort psp list", () => {
+describe("Checkout show and sort psp list", () => {
 
   it("Should show psp sorted list by fee", async() => {
    
@@ -62,7 +62,7 @@ describe.only("Checkout show and sort psp list", () => {
 
     const pspEditButton = await page.waitForSelector(pspEditButtonSelector);
     await pspEditButton.click();
-    await new Promise(r => setTimeout(r, 500));
+    await page.waitForSelector(".pspFeeValue");
     const pspOriginalElements = await page.$$(".pspFeeValue");
     const originalPspFeeLisValues = await Promise.all(
       Array.from(pspOriginalElements).map(async (element) => {
@@ -137,9 +137,10 @@ describe.only("Checkout show and sort psp list", () => {
     })
     const pspEditButton = await page.waitForSelector(pspEditButtonSelector);
     await pspEditButton.click();
-    await new Promise(r => setTimeout(r, 500));
-    const pspOriginalElements = await page.$$(".pspFeeName");
-
+    
+    //Initially is sorted by fee ascending
+    await page.waitForSelector(".pspFeeValue");
+    const pspOriginalElements = await page.$$(".pspFeeValue");
     const originalPspFeeLisValues = await Promise.all(
       Array.from(pspOriginalElements).map(async (element) => {
         const text = await element.evaluate((el) => el.textContent);
@@ -158,15 +159,11 @@ describe.only("Checkout show and sort psp list", () => {
 
     const pspNameSortButton = await page.waitForSelector(pspNameSortButtonId);
     await pspNameSortButton.click();
-    await new Promise(r => setTimeout(r, 500));
     // Wait for the elements and get the list of divs
     const pspSortedElements = await page.$$(".pspFeeName");
     // Extract numeric content from each div and return as an array
     const decreasingPspFeeListValues = await Promise.all(
-      Array.from(pspSortedElements).map(async (element) => {
-        const text = await element.evaluate((el) => el.textContent);
-        return parseFloat(text) || ""; 
-      })
+      Array.from(pspSortedElements).map(async (element) => await element.evaluate((el) => el.textContent))
     );
 
     expect(Array.isArray(decreasingPspFeeListValues)).toBe(true);

--- a/e2e-tests/src/npg/psp-sorting.npg.integration.test.ts
+++ b/e2e-tests/src/npg/psp-sorting.npg.integration.test.ts
@@ -137,39 +137,40 @@ describe("Checkout show and sort psp list", () => {
     })
     const pspEditButton = await page.waitForSelector(pspEditButtonSelector);
     await pspEditButton.click();
-    
-    //Initially is sorted by fee ascending
-    await page.waitForSelector(".pspFeeValue");
-    const pspOriginalElements = await page.$$(".pspFeeValue");
-    const originalPspFeeLisValues = await Promise.all(
-      Array.from(pspOriginalElements).map(async (element) => {
-        const text = await element.evaluate((el) => el.textContent);
-        // We want to skip the Dollar, Euro, or any currency placeholder
-        let numbers = text.match(/[\d,]+/g); // This will match sequences of digits and commas
-        let result = numbers ? numbers.join("").replace(",",".") : ""; // Join the matched numbers if any and replace , as separator with .
-        return parseFloat(result) || 0; // Convert to number, default to 0 if NaN
-      })
-    );
 
-    expect(Array.isArray(originalPspFeeLisValues)).toBe(true);
-    expect(originalPspFeeLisValues.length > 0).toBe(true);
-    for (let i = 0; i < originalPspFeeLisValues.length - 1; i++) {
-      expect(originalPspFeeLisValues[i]).toBeLessThanOrEqual(originalPspFeeLisValues[i + 1]);
-    }
-
+    await page.waitForSelector(".pspFeeName");
+   
+    //Initially is sorted by fee, so we click sort by name instead
     const pspNameSortButton = await page.waitForSelector(pspNameSortButtonId);
     await pspNameSortButton.click();
+   
     // Wait for the elements and get the list of divs
-    const pspSortedElements = await page.$$(".pspFeeName");
-    // Extract numeric content from each div and return as an array
+    const pspSortedElementsByNameAsc = await page.$$(".pspFeeName");
+    // Extract value content from each div and return as an array
     const decreasingPspFeeListValues = await Promise.all(
-      Array.from(pspSortedElements).map(async (element) => await element.evaluate((el) => el.textContent))
+      Array.from(pspSortedElementsByNameAsc).map(async (element) => await element.evaluate((el) => el.textContent))
     );
 
     expect(Array.isArray(decreasingPspFeeListValues)).toBe(true);
     expect(decreasingPspFeeListValues.length > 0).toBe(true);
     for (let i = 0; i < decreasingPspFeeListValues.length - 1; i++) {
       expect(decreasingPspFeeListValues[i].localeCompare(decreasingPspFeeListValues[i + 1])).toBeGreaterThanOrEqual(0);
+    }
+
+    // inverse sort
+    await pspNameSortButton.click();
+   
+    // Wait for the elements and get the list of divs
+    const pspSortedElementsByNameDesc = await page.$$(".pspFeeName");
+    // Extract value content from each div and return as an array
+    const increasingPspFeeListValues = await Promise.all(
+      Array.from(pspSortedElementsByNameDesc).map(async (element) => await element.evaluate((el) => el.textContent))
+    );
+
+    expect(Array.isArray(increasingPspFeeListValues)).toBe(true);
+    expect(increasingPspFeeListValues.length > 0).toBe(true);
+    for (let i = 0; i < increasingPspFeeListValues.length - 1; i++) {
+      expect(increasingPspFeeListValues[i].localeCompare(increasingPspFeeListValues[i + 1])).toBeLessThanOrEqual(0);
     }
     await cancelPaymentAction()
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- The previous main div was located on /html/body/div[1]/div/div[2]/... other tags
Now the main div is located on /html/body/div[1]/div/main/... other tags
- fix psp-sorting tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To align with Changes from here 
https://github.com/pagopa/pagopa-checkout-fe/pull/399

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
