### PR TITLE
fix: add click on confirm button on logout modal

### DIFF
--- a/e2e-tests/src/auth/checkout.spid-auth.integration.test.ts
+++ b/e2e-tests/src/auth/checkout.spid-auth.integration.test.ts
@@ -58,6 +58,7 @@ describe("Checkout authentication spid", () => {
             const lis = document.getElementsByTagName('li')
             lis[0].click()
         });
+        await sleep(500);
         const confirmButton = await page.waitForSelector("#logoutModalConfirmButton");
         await confirmButton.click();
         await page.waitForSelector('#login-header button', { visible: true });

--- a/e2e-tests/src/auth/checkout.spid-auth.integration.test.ts
+++ b/e2e-tests/src/auth/checkout.spid-auth.integration.test.ts
@@ -58,10 +58,9 @@ describe("Checkout authentication spid", () => {
             const lis = document.getElementsByTagName('li')
             lis[0].click()
         });
-        await sleep(200);
-
+        const confirmButton = await page.waitForSelector("#logoutModalConfirmButton");
+        await confirmButton.click();
         await page.waitForSelector('#login-header button', { visible: true });
-
         const button = await page.$x("//button[contains(., 'Accedi')]");
         expect(button.length).toBeGreaterThan(0);
     });


### PR DESCRIPTION
Note for reviewers: UAT logout tests are failing because info modal on logout is currently deployed in DEV env only.
Once f.e. is deployed in UAT too this test will succeed (the modification was done in test common part shared between DEV and UAT E2E test)
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add click on confirm button on logout modal after click on logout key
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add click on confirm button on logout modal after click on logout key
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
