### PR TITLE
Fix e2e tests

### DIFF
--- a/e2e-tests/src/auth/checkout.spid-auth.integration.test.ts
+++ b/e2e-tests/src/auth/checkout.spid-auth.integration.test.ts
@@ -43,10 +43,10 @@ describe("Checkout authentication spid", () => {
             const lis = document.getElementsByTagName('li')
             lis[0].click()
         });
-        await sleep(500);
         //#3 confirm logout operation
         const confirmButton = await page.waitForSelector("#logoutModalConfirmButton");
         await confirmButton.click();
+        await sleep(500);
         //#4 check that login button is visible again after logout
         await page.waitForSelector('#login-header button', { visible: true });
         const button = await page.$x("//button[contains(., 'Accedi')]");

--- a/e2e-tests/src/auth/checkout.spid-auth.integration.test.ts
+++ b/e2e-tests/src/auth/checkout.spid-auth.integration.test.ts
@@ -28,16 +28,15 @@ describe("Checkout authentication spid", () => {
         //await selectLanguage("it");
     });
 
-    it("Should Login Successfully At Checkout", async() => {
+    it("Should perform login and logout operation successfully", async() => {
+        //#1 perform login 
         await page.waitForSelector('#login-header button');
         await page.locator('#login-header button').click();
         if (CHECKOUT_URL.includes("uat")) await oneIdentityLogin(page);
         else await identityProviderMock(page);
-    });
-
-    it("Should Logout Successfully From Checkout", async() => {
         await page.waitForSelector('button');
 
+        //#2 click on user button and search for exit sub menu  
         await page.evaluate(() => {
             const buttons = document.getElementsByTagName('button')
             buttons[0].click()
@@ -45,10 +44,13 @@ describe("Checkout authentication spid", () => {
             lis[0].click()
         });
         await sleep(500);
+        //#3 confirm logout operation
         const confirmButton = await page.waitForSelector("#logoutModalConfirmButton");
         await confirmButton.click();
+        //#4 check that login button is visible again after logout
         await page.waitForSelector('#login-header button', { visible: true });
         const button = await page.$x("//button[contains(., 'Accedi')]");
         expect(button.length).toBeGreaterThan(0);
     });
+
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Fix E2E for logout (failing click on button) moving sleep after confirm click
- merge login and logout tests into an unique test to make those test independent on execution order
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Logout test strictly depends on test ordering that can be changed if test executor executes test in parallel.
Since to check logout behavior user needs to be logged in first the login and logout tests have been merged in one test that now perform checks against login and logout sequentially and make test resilient to ordering

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=206987&view=logs&j=35f9fa2d-a991-5284-70a4-ccfc5bd48f98&t=35f9fa2d-a991-5284-70a4-ccfc5bd48f98
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
