### PR TITLE
fix: add polling after auth request api to await for view update stat…

### DIFF
--- a/api-tests/checkout-tests/npg/checkout-for-ecommerce-api.tests.json
+++ b/api-tests/checkout-tests/npg/checkout-for-ecommerce-api.tests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "36817319-fdb4-4ed8-8d1a-bd5d4945736b",
+		"_postman_id": "05471962-1fc7-4c73-b4b4-9b2ece35c710",
 		"name": "Ecommerce for Checkout API - NPG",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "23305473"
+		"_exporter_id": "23963988"
 	},
 	"item": [
 		{
@@ -2955,12 +2955,46 @@
 					"listen": "test",
 					"script": {
 						"exec": [
+							"async function executeGetTransactionPollingUntilStatus(wantedStatus) {",
+							"    const transactionId = pm.environment.get(\"TRANSACTION_ID\");",
+							"    const authToken = pm.environment.get(\"AUTH_TOKEN\");",
+							"    const getTransaction = {",
+							"        url: `${pm.environment.get(\"CHECKOUT_HOST\")}/ecommerce/checkout/v2/transactions/${transactionId}`,",
+							"        method: 'GET',",
+							"        header: {",
+							"            'Content-Type': 'application/json',",
+							"            'Authorization': `Bearer ${authToken}`",
+							"        }",
+							"    };",
+							"    const maxAttempts = 10;",
+							"    var counter = 0;",
+							"    var transactionStatus = null;",
+							"    while (counter < maxAttempts && transactionStatus != wantedStatus) {",
+							"        await new Promise(r => setTimeout(r, 1000));",
+							"        await new Promise((resolve, reject) => pm.sendRequest(getTransaction, (error, response) => {",
+							"            if (error) {",
+							"                console.log(`Error retrieving transaction by id: ${error.code}`);",
+							"                reject(error)",
+							"            } else {",
+							"                const responseBody = response.json();",
+							"                transactionStatus = responseBody.status;",
+							"                console.log(`Transaction with id: [${transactionId}] status: [${transactionStatus}]`)",
+							"                resolve(transactionStatus);",
+							"            }",
+							"        }));",
+							"        counter++;",
+							"    }",
+							"    if (transactionStatus != wantedStatus) {",
+							"            throw new Error(`Transaction in wrong status after polling. Wanted: [${wantedStatus}], received: [${transactionStatus}]`)",
+							"        }",
+							"}",
 							"pm.test(\"[eCommerce for checkout] New NPG authorization request with POST transactions/:transactionId/auth-request (lang: it)\", function(){",
 							"    pm.response.to.have.status(200);",
 							"    const response = pm.response.json();",
 							"    pm.expect(response.authorizationUrl).to.be.a(\"string\");",
 							"    const expectedAuthorizationRequestId = pm.environment.get(\"ORDER_ID\");",
 							"    pm.expect(response.authorizationRequestId).to.be.eq(expectedAuthorizationRequestId);",
+							"    executeGetTransactionPollingUntilStatus(\"AUTHORIZATION_REQUESTED\");",
 							"});"
 						],
 						"type": "text/javascript",


### PR DESCRIPTION
…us propagation

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add GET transaction polling to wait for update async status propagation (CDC) after POST auth request process
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This modification is needed in order to make sure that CDC service have updated transaction view before continuing collection run and perform other checks against GET transaction api call.
without this check GET transaction tests were performed before view being updated, failing because of wrong status detected
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
local collection run
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
